### PR TITLE
Add ranges for x,y in Question 6 in Probability Theory section of Warm-up Exercises

### DIFF
--- a/exercises/exercises.tex
+++ b/exercises/exercises.tex
@@ -220,7 +220,7 @@ We will cover conditional probability more later, but for now just think it thro
 \end{question}
 
 \begin{question}[Multivariate Integration]
-Consider two continuous random variables $X,Y$ with joint density $p(x, y) = C\cdot (x^2 + xy)$.
+Consider two continuous random variables $X,Y$ with joint density $p(x, y) = C\cdot (x^2 + xy)$ when $x \in [0, 1]$ and $y \in [0, 1]$, and $0$ elsewhere.
 \begin{enumerate}[label=\alph*.]
     \item Find $C$.
     \item Find $\prob{0.3 \leq X \leq 0.5}$.


### PR DESCRIPTION
Add ranges for x,y in Question 6 in Probability Theory section of Warm-up Exercises.

Set range of x and y to [0,1] based on Question 4 in the same section. This is needed because without it, it is impossible to do integration. 

Image below is a screenshot where I made the changes. 

<img width="745" alt="Screenshot 2022-10-10 at 11 19 34" src="https://user-images.githubusercontent.com/18008640/194844904-21d86df1-3b06-4662-9039-92fb6c44e616.png">

Please feel free to change them because it's not my mother tongue, and my changes to the question might not be clear. 
