### PR TITLE
Q10 answer fix

### DIFF
--- a/exercises/warm-up-answers.tex
+++ b/exercises/warm-up-answers.tex
@@ -105,9 +105,9 @@ $\y = (24, -14, -12)^\top$, $|| \x ||_2 = \sqrt{23}$, $|| \y ||_2 = \sqrt{916}$.
 
 Note that by definition the $\ell_2$ norm of a vector is $|| \x ||_2 = \sqrt{\x^\top \x}$.
 
-\paragraph{Question \ref{q:basis}} 1, 2, 3. 
+\paragraph{Question \ref{q:basis}} 1, 2.
 
-A set of vectors $\{\mathbf{b}_1, ..., \mathbf{b}_K \}$ with $\mathbf{b}_k \in \mathbb{R}^d$ can form a basis of $\mathbb{R}^d$ iff $K \geq d$ and there exists a subset of $d$ vectors within the set, such that they are orthogonal to each other.
+A set of vectors $\{\mathbf{b}_1, ..., \mathbf{b}_K \}$ with $\mathbf{b}_k \in \mathbb{R}^d$ can form a basis of $\mathbb{R}^d$ iff $K \geq d$ and there exists a subset of $d$ vectors within the set, such that they are linearly independent to each other.
 
 \paragraph{Question \ref{q:span}} 2, 5. 
 

--- a/exercises/warm-up-answers.tex
+++ b/exercises/warm-up-answers.tex
@@ -107,7 +107,7 @@ Note that by definition the $\ell_2$ norm of a vector is $|| \x ||_2 = \sqrt{\x^
 
 \paragraph{Question \ref{q:basis}} 1, 2.
 
-A set of vectors $\{\mathbf{b}_1, ..., \mathbf{b}_K \}$ with $\mathbf{b}_k \in \mathbb{R}^d$ can form a basis of $\mathbb{R}^d$ iff $K \geq d$ and there exists a subset of $d$ vectors within the set, such that they are linearly independent to each other.
+A set of vectors $\{\mathbf{b}_1, ..., \mathbf{b}_K \}$ with $\mathbf{b}_k \in \mathbb{R}^d$ can form a basis of $\mathbb{R}^d$ iff $K = d$ and the vectors are linearly independent to each other.
 
 \paragraph{Question \ref{q:span}} 2, 5. 
 


### PR DESCRIPTION
The answer in q10 says that the basis vectors must be orthogonal, but I don't think this is the case, they just need to be linearly independent. I also believe that the number of vectors in the basis set should be equal to the number of dimensions in order for them to be linearly independent and span the space. This would make (3) ({(1, −1), (0, 2), (2, 1)}) not a valid basis for R^2.
Please let me know if I'm wrong about this or if I'm using a different definition!