### PR TITLE
Autodiff slides page 12 equation (1) possible typo

### DIFF
--- a/slides/l03p1-autodiff.tex
+++ b/slides/l03p1-autodiff.tex
@@ -215,7 +215,7 @@ We want to compute the gradient w.r.t.~$x_i$.
 \begin{itemize}
 \item For the input value $\vx = \va$, compute the numerical value of
 \begin{align}
-\pderiv[v_j]{x_i} = \sum_{k \in \mathrm{inputs}(i)} \pderiv[v_j]{v_k}\pderiv[v_k]{x_i} \label{eq:fwd}
+\pderiv[v_j]{x_i} = \sum_{k \in \mathrm{inputs}(j)} \pderiv[v_j]{v_k}\pderiv[v_k]{x_i} \label{eq:fwd}
 \end{align}
 \end{itemize} \pause
 \item We end up with $\partial \mathrm{out} / \partial x_i$. \pause


### PR DESCRIPTION
Hello, 

In the autodiff slides page 12 equation (1), when computing the derivative of node $v_j$ w.r.t variable $x_i$, I think we should sum the downstream derivative products for all input nodes of $v_j$ instead of $v_i$? 

<img width="184" alt="image" src="https://user-images.githubusercontent.com/77429740/197062691-e4f8e329-c40a-4a49-b622-ce24f54049c2.png">


