### PR TITLE
Add script to build exercises

### DIFF
--- a/.github/workflows/build_exercises.yml
+++ b/.github/workflows/build_exercises.yml
@@ -1,0 +1,20 @@
+name: "Build LaTeX Sources"
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  example_matrix:
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: "Check out code"
+        uses: actions/checkout@v3
+      - name: "Build exercises"
+        run: ./bin/compile_exercises.sh --clean

--- a/.github/workflows/build_exercises.yml
+++ b/.github/workflows/build_exercises.yml
@@ -8,13 +8,29 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
-  example_matrix:
+  build_with_docker:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-latest]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Check out code"
         uses: actions/checkout@v3
+      - name: "Build exercises"
+        run: ./bin/compile_exercises.sh --clean
+
+  # Docker is not available on macos runners
+  build_with_colima:
+    strategy:
+      matrix:
+        os: [macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: "Check out code"
+        uses: actions/checkout@v3
+      - name: "Install colima"
+        run: brew install docker colima
+      - name: "Start colima"
+        run: colima start
       - name: "Build exercises"
         run: ./bin/compile_exercises.sh --clean

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@
 *.snm
 \#*
 .*
+!.github
 *.nav

--- a/README.md
+++ b/README.md
@@ -53,4 +53,10 @@ Below is a syllabus of the course, together with a rough plan for the term. This
     - Exercises: Simple Bayesian inference (coins), derive BLR.
 - Lecture 12: Bias-variance trade-off (YL)
 - Lecture 13 & 14: Dimensionality Reduction & PCA (YL 2L)
- 
+
+## Building the LaTeX sources
+If you are using MacOS or Linux and have docker [installed]
+(https://docs.docker.com/get-docker/) you can build the exercises from source
+using `./bin/compile_exercises.sh`. Unfortunately we still don't have a native
+Windows script, feel free to contribute one if you are a Windows user and you
+will be rewarded with cake!

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Below is a syllabus of the course, together with a rough plan for the term. This
 ## Building the LaTeX sources
 If you are using MacOS or Linux and have docker [installed]
 (https://docs.docker.com/get-docker/) you can build the exercises from source
-using `./bin/compile_exercises.sh`. Unfortunately we still don't have a native
+using `./bin/compile_exercises.sh`. Similarly, you can build non-handout
+versions of the slides (i.e. without animations) using
+`./bin/compile_course_slides.sh`.Unfortunately we still don't have a native
 Windows script, feel free to contribute one if you are a Windows user and you
 will be rewarded with cake!

--- a/bin/compile_course_slides.sh
+++ b/bin/compile_course_slides.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# ----------
+# This script compiles the slides .tex files in handout format
+# ----------
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]:-${(%):-%x}}" )" >/dev/null 2>&1 && pwd )"
+PROJ_ROOT="${THIS_DIR}/.."
+
+if [[ $1 == "--clean" ]]; then
+    docker run --rm \
+      -v ${PROJ_ROOT}:/workdir \
+      -u $(id -u):$(id -g) \
+      --workdir /workdir/slides \
+    csegarragonz/latex-docker:0.1.2 clean
+fi
+
+# Ignore failed searches
+shopt -s nullglob
+
+for file_name in ${PROJ_ROOT}/slides/*.tex; do
+    base_file_name=$(basename ${file_name})
+
+    # For each file, first check if already have the `handout` tag at the end.
+    # Note that this relies on, if `handout` is set, then it must be set at
+    # the end (right before {beamer}). This fits the current needs, but if
+    # something more generic is needed we can sprinkle more regex magic
+    if ! grep -q 'handout]{beamer}' ${file_name}; then
+        sed -i 's/]{beamer}/,handout]{beamer}/g' ${file_name}
+    fi
+
+    docker run --rm \
+      -v ${PROJ_ROOT}:/workdir \
+      -u $(id -u):$(id -g) \
+      --workdir /workdir/slides \
+      csegarragonz/latex-docker:0.1.2 /workdir/slides/${base_file_name} > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "Processed: ${base_file_name}"
+    else
+        echo "ERROR! Could not process: ${base_file_name}" >&2
+        exit 1
+    fi
+
+    # Finally, remove the handout option for the exercises
+    if grep -q 'handout]{beamer}' ${file_name}; then
+        sed -i 's/,handout]{beamer}/]{beamer}/g' ${file_name}
+    fi
+done
+

--- a/bin/compile_exercises.sh
+++ b/bin/compile_exercises.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]:-${(%):-%x}}" )" >/dev/null 2>&1 && pwd )"
+PROJ_ROOT="${THIS_DIR}/.."
+
+if [[ $1 == "--clean" ]]; then
+    docker run --rm \
+      -v ${PROJ_ROOT}:/workdir \
+      -u $(id -u):$(id -g) \
+      --workdir /workdir/exercises \
+    csegarragonz/latex-docker:0.1.2 clean
+fi
+
+docker run --rm \
+  -v ${PROJ_ROOT}:/workdir \
+  -u $(id -u):$(id -g) \
+  --workdir /workdir/exercises \
+  csegarragonz/latex-docker:0.1.2 /workdir/exercises/exercises.tex

--- a/slides/L01P01-intro.tex
+++ b/slides/L01P01-intro.tex
@@ -1,5 +1,5 @@
 %% Time-stamp: <2018-10-18 20:24:12 (marc)>
-\documentclass[xcolor=x11names,compress,mathserif,handout]{beamer}
+\documentclass[xcolor=x11names,compress,mathserif]{beamer}
 
 \newcommand{\hackspace}{\hspace{4.2mm}}
 \newcommand{\showstudent}[1]{}

--- a/slides/L01P02-motivation-param-est.tex
+++ b/slides/L01P02-motivation-param-est.tex
@@ -1,5 +1,5 @@
 %% Time-stamp: <2018-10-18 20:24:12 (marc)>
-\documentclass[xcolor=x11names,compress,mathserif,handout]{beamer}
+\documentclass[xcolor=x11names,compress,mathserif]{beamer}
 
 \newcommand{\hackspace}{\hspace{4.2mm}}
 \newcommand{\showstudent}[1]{}

--- a/slides/L01P03-curvefitting.tex
+++ b/slides/L01P03-curvefitting.tex
@@ -1,5 +1,5 @@
 %% Time-stamp: <2018-10-18 20:24:12 (marc)>
-\documentclass[xcolor=x11names,compress,mathserif,handout]{beamer}
+\documentclass[xcolor=x11names,compress,mathserif]{beamer}
 
 \newcommand{\hackspace}{\hspace{4.2mm}}
 \newcommand{\showstudent}[1]{}

--- a/slides/L01P04-vectorcalc.tex
+++ b/slides/L01P04-vectorcalc.tex
@@ -1,5 +1,5 @@
 %% Time-stamp: <2018-10-18 20:24:12 (marc)>
-\documentclass[xcolor=x11names,compress,mathserif,handout]{beamer}
+\documentclass[xcolor=x11names,compress,mathserif]{beamer}
 
 \newcommand{\hackspace}{\hspace{4.2mm}}
 \newcommand{\showstudent}[1]{}


### PR DESCRIPTION
This PR adds a script to build the exercises (under `./bin/compile_exercises.sh`) and a Github Action that will try to build the exercises on every commit on a new PR (that is not marked as draft). This way, we will now that new PRs don't break the compilation.

Further, the script uses `docker` which means that students won't have to install heavy LaTeX distributions, but only Docker. Admittedly the docker image you need to pull is also quite heavy (as it includes LaTeX) but using the same docker image for everybody removes incompatibility issues due to broken or out-of-date installations.

Unfortunately, my changes to the actions file don't trigger the checks in this repo (as I am pushing to my fork, and I am a first time contributor). I am checking them in another PR open in my own fork, you can see an example of the workflow [here](https://github.com/csegarragonz/mml-autumn-2022/actions/runs/3297426624/jobs/5438228342).

The tests are not particularly fast, as they need to pull the image from DockerHub. They take about:
* 5' for Linux
* 13' for MacOS

If this is too slow, I can look into optimizing it but I don't think its prioritary.

Lastly, I don't have access to a Windows machine, but the shell script should be easy to replicate. Maybe someone with a Windows box can reach out to me and I can flush out a similar script for them.

@markvdw this is ready to be reviewed, let me know what you think about it.

Closes #8 