### PR TITLE
Small typo in answers (repeated 5 instead of 5, 6)

### DIFF
--- a/exercises/warm-up-answers.tex
+++ b/exercises/warm-up-answers.tex
@@ -138,7 +138,7 @@ A(s) =
 3 &\text{, if } s \in \{ (\dC, \dA), (\dC,\dB), (\dC,\dC), (\dC,\dD), (\dC,\dE), (\dC,\dF) \} \\
 4 &\text{, if } s \in \{ (\dD, \dA), (\dD,\dB), (\dD,\dC), (\dD,\dD), (\dD,\dE), (\dD,\dF) \} \\
 5 &\text{, if } s \in \{ (\dE, \dA), (\dE,\dB), (\dE,\dC), (\dE,\dD), (\dE,\dE), (\dE,\dF) \} \\
-5 &\text{, if } s \in \{ (\dF, \dA), (\dF,\dB), (\dF,\dC), (\dF,\dD), (\dF,\dE), (\dF,\dF) \}
+6 &\text{, if } s \in \{ (\dF, \dA), (\dF,\dB), (\dF,\dC), (\dF,\dD), (\dF,\dE), (\dF,\dF) \}
 \end{cases} \\
 B(s) =
 \begin{cases}
@@ -147,7 +147,7 @@ B(s) =
 3 &\text{, if } s \in \{ (\dA,\dC), (\dB,\dC), (\dC,\dC), (\dD,\dC), (\dE,\dC), (\dF,\dC) \} \\
 4 &\text{, if } s \in \{ (\dA,\dD), (\dB,\dD), (\dC,\dD), (\dD,\dD), (\dE,\dD), (\dF,\dD) \} \\
 5 &\text{, if } s \in \{ (\dA,\dE), (\dB,\dE), (\dC,\dE), (\dD,\dE), (\dE,\dE), (\dF,\dE) \} \\
-5 &\text{, if } s \in \{ (\dA,\dF), (\dB,\dF), (\dC,\dF), (\dD,\dF), (\dE,\dF), (\dF,\dF) \}
+6 &\text{, if } s \in \{ (\dA,\dF), (\dB,\dF), (\dC,\dF), (\dD,\dF), (\dE,\dF), (\dF,\dF) \}
 \end{cases}
 \end{align*}
 We can find the PMFs by counting the number of occurrences in $\Omega$. For instance:


### PR DESCRIPTION
In the warm up exercises, the question about rolling two dice has a small typo in the PMF where instead of 1, 2, 3, 4, 5, 6 you have written 1, 2, 3, 4 ,5, 5