### PR TITLE
Typos L11P1, L09P1, L07P1, exercise answers Q35, Q38

### DIFF
--- a/coursework/mml_cw_1.ipynb
+++ b/coursework/mml_cw_1.ipynb
@@ -158,7 +158,7 @@
     "We can approximate this by calculating the expression for a small but finite $\\Delta x$ along each dimension, which\n",
     "is known as the _finite-differences_ approximation.\n",
     "\n",
-    "Complete the function ```grad_fn(fn, x)``` such that it returns the gradients for any function ```fn``` at a point **x** using the method of finite differences. Use a delta of $1\\times 10^{-5}$.\n",
+    "Complete the function ```grad_fd(fn, x)``` such that it returns the gradients for any function ```fn``` at a point **x** using the method of finite differences. Use a delta of $1\\times 10^{-5}$.\n",
     "\n",
     "_The function should take a columnar numpy (2, 1) vector for ‘x’ as input, and output a\n",
     "numpy (1, 2) row vector for the gradient._"
@@ -207,7 +207,7 @@
    "source": [
     "---\n",
     "#### Question 2.b - Analytical Gradients (4 Points)\n",
-    "Complete the functions ```f1_grad(x)```, ```f2_grad(x)``` and ```f3_grad(x)``` that return\n",
+    "Complete the functions ```f1_grad_exact(x)```, ```f2_grad_exact(x)``` and ```f3_grad_exact(x)``` that return\n",
     "gradients of f1, f2 and f3, using your own derivations.\n",
     "\n",
     "_The functions should take a columnar numpy (2, 1) vector for **x** as input, and output a\n",
@@ -302,10 +302,9 @@
     "---\n",
     "### Question 3 - Gradient Descent (8 Points)\n",
     "Use your gradients to implement a gradient descent algorithm with 50 iterations\n",
-    "to find a local minimum for both f2 and f3, by finishing the function grad descent(fn,\n",
-    "grad fn).\n",
+    "to find a local minimum for both f2 and f3, by finishing the function ```gradient_descent(fn, grad_fn)```.\n",
     "\n",
-    "For visualizing (and debugging) your gradient descent function, we provide some plotting code. This is contained in the cell below, so be sure to exectue it. You can use this function on f1 by passing in the other functions, for example: ```plot_grad_descent(f1, f1_grad_exact, gradient_descent)``` once you have completed the ```gradient_descent(fn, grad_fn)``` function. You can also pass in ```xrange=(x_min, x_max)``` and likewise for ```yrange``` to adjust the plotted region."
+    "For visualizing (and debugging) your gradient descent function, we provide some plotting code. This is contained in the cell below, so be sure to exectue it. You can use this function on f1 by passing in the other functions, for example: ```plot_grad_descent(f1, f1_grad_exact, gradient_descent)``` once you have completed the ```gradient_descent(fn, grad_fn)``` function. You can also pass in ```x1range=(x_min, x_max)``` and likewise for ```x2range``` to adjust the plotted region."
    ]
   },
   {
@@ -316,11 +315,11 @@
    "source": [
     "# Provide function for plotting gradient descent\n",
     "import matplotlib.pyplot as plt\n",
-    "def plot_grad_descent(fn, fn_grad, gradient_descent_fn, xrange=(-1, 1), yrange=(-1,1), **kwargs):\n",
+    "def plot_grad_descent(fn, fn_grad, gradient_descent_fn, x1range=(-1, 1), x2range=(-1,1), **kwargs):\n",
     "    title = 'Plotting function #'+ fn_grad.__name__.split('_')[0][-1]\n",
     "    # Define plotting range for x- and y- axis.\n",
-    "    x1min, x1max = xrange\n",
-    "    x2min, x2max = yrange\n",
+    "    x1min, x1max = x1range\n",
+    "    x2min, x2max = x2range\n",
     "\n",
     "    # Evaluate function everywhere within the defined range for the contour plot\n",
     "    x1 = np.linspace(x1min, x1max, 100)\n",
@@ -361,7 +360,7 @@
    },
    "outputs": [],
    "source": [
-    "def gradient_descent(fn, grad_fn, start_x=3.0, start_y=3.0, lr=0.001, n_steps=10, silent=False):\n",
+    "def gradient_descent(fn, grad_fn, start_x1=3.0, start_x2=3.0, lr=0.001, n_steps=10, silent=False):\n",
     "    \"\"\" Function that performs gradient descent.\n",
     "\n",
     "    Inputs: \n",
@@ -378,7 +377,7 @@
     "        - the value at the minimum: float\n",
     "    \"\"\"\n",
     "\n",
-    "    start_loc = np.array([[start_x], [start_y]])\n",
+    "    start_loc = np.array([[start_x1], [start_x2]])\n",
     "    trajectory = [start_loc]\n",
     "\n",
     "    ...\n",
@@ -400,8 +399,8 @@
    "source": [
     "# Here we'll use the plotting function and specify custom starting points and plotting ranges\n",
     "plot_grad_descent(f1, f1_grad_exact, gradient_descent,\n",
-    "                  xrange=(2, 3), yrange=(2, 4),\n",
-    "                  start_x=3, start_y=3, lr=0.005\n",
+    "                  x1range=(2, 3), x2range=(2, 4),\n",
+    "                  start_x1=3, start_x2=3, lr=0.005\n",
     ")"
    ]
   },
@@ -441,14 +440,14 @@
    "source": [
     "# Here we'll use the plotting function and specify custom starting points and plotting ranges\n",
     "# For F2 \n",
-    "f2_start_x = ...\n",
-    "f2_start_y = ...\n",
+    "f2_start_x1 = ...\n",
+    "f2_start_x2 = ...\n",
     "f2_lr = ...\n",
     "f2_n_steps = ...\n",
     "\n",
     "plot_grad_descent(f2, f2_grad_exact, gradient_descent,\n",
-    "                  xrange=(-1.5, 1.5), yrange=(-1.5, 1.5),\n",
-    "                  start_x=f2_start_x, start_y=f2_start_y, lr=f2_lr, n_steps=f2_n_steps, silent=True\n",
+    "                  x1range=(-1.5, 1.5), x2range=(-1.5, 1.5),\n",
+    "                  start_x1=f2_start_x1, start_x2=f2_start_x2, lr=f2_lr, n_steps=f2_n_steps, silent=True\n",
     ")"
    ]
   },
@@ -461,14 +460,14 @@
    "outputs": [],
    "source": [
     "# For F3 \n",
-    "f3_start_x = ...\n",
-    "f3_start_y = ...\n",
+    "f3_start_x1 = ...\n",
+    "f3_start_x2 = ...\n",
     "f3_lr = ...\n",
     "f3_n_steps = ...\n",
     "\n",
     "plot_grad_descent(f3, f3_grad_exact, gradient_descent,\n",
-    "                  xrange=(-1.5, 1.5), yrange=(-1.5, 1.5),\n",
-    "                  start_x=f3_start_x, start_y=f3_start_y, lr=f3_lr, n_steps=f3_n_steps, silent=True\n",
+    "                  x1range=(-1.5, 1.5), x2range=(-1.5, 1.5),\n",
+    "                  start_x1=f3_start_x1, start_x2=f3_start_x2, lr=f3_lr, n_steps=f3_n_steps, silent=True\n",
     ")"
    ]
   },
@@ -527,7 +526,7 @@
    },
    "outputs": [],
    "source": [
-    "plot_grad_descent(f2, f2_grad_exact, gradient_descent, lr=0.4, n_steps=50, silent=True, xrange=(-20, 20), yrange=(-20, 20))"
+    "plot_grad_descent(f2, f2_grad_exact, gradient_descent, lr=0.4, n_steps=50, silent=True, x1range=(-20, 20), x2range=(-20, 20))"
    ]
   },
   {
@@ -586,7 +585,7 @@
     "with respect to $\\vec{z}$, where $\\vec{p}$ and $\\vec{q}$ are constants, and $\\mathbf{D}$ is the matrix of squared distances between elements of $\\vec{z}$:\n",
     "$$ D_{ij} = \\exp(-(z_i - z_j)^2). $$\n",
     "\n",
-    "Get warmed up by implementing the the function ```sq_dist_fwd(p,q,x)``` which computes $\\vec{s}$."
+    "Get warmed up by implementing the the function ```sq_dist_fwd(p,q,z)``` which computes $\\vec{s}$."
    ]
   },
   {
@@ -604,7 +603,7 @@
     "# Naive solution\n",
     "p = np.random.rand(4)\n",
     "q = np.random.rand(4)\n",
-    "def sq_dist_fwd(p,q,x):\n",
+    "def sq_dist_fwd(p,q,z):\n",
     "    \"\"\" Compute the inner product of p and q, projected through a matrix consisting of the \n",
     "        squared distance between elements of a variable x. All vectors are length x.shape[0].\n",
     "        To be compatible with autograd, we need to avoid using assignments on array indices \n",
@@ -636,7 +635,7 @@
    "source": [
     "#### Question 4.b - Analytical Derivate of Squared Distances (2 Points)\n",
     "In order to override autograd's gradient for our squared distance function, we need to derive it ourselves - compute the derivate\n",
-    "$$\\frac{\\partial \\vec{s}}{\\partial \\vec{z}} =\\sum_{i j} a_i b_j \\frac{\\partial D_{i j}}{\\partial \\vec{z}} $$\n",
+    "$$\\frac{\\partial \\vec{s}}{\\partial \\vec{z}} =\\sum_{i j} p_i q_j \\frac{\\partial D_{i j}}{\\partial \\vec{z}} $$\n",
     "with respect to one element of $\\vec{z}$\n"
    ]
   },
@@ -658,7 +657,7 @@
     "<!-- END QUESTION -->\n",
     "\n",
     "#### Question 4.c - Implement the Derivative (2 Points)\n",
-    "With the analytical derivate in hand, complete the ```sq_dist_grad_elem(a, b, x, z)``` function which computes the gradient with respect to the $n^{th}$ dimension of $\\vec{z}$ and the corresponding function ```sq_dist_grad``` which computes the gradient vector.\n",
+    "With the analytical derivate in hand, complete the ```sq_dist_grad_elem(p, q, z, n)``` function which computes the gradient with respect to the $n^{th}$ dimension of $\\vec{z}$ and the corresponding function ```sq_dist_grad``` which computes the gradient vector.\n",
     "\n"
    ]
   },
@@ -1030,7 +1029,7 @@
       {
        "cases": [
         {
-         "code": ">>> c = np.array([[4], [5]])\n>>> dummy_fn = lambda x: float(c.T @ x)\n>>> dummy_fn_grad = lambda x: c.T\n>>> dummy_start_x, dummy_start_y = 1.0, 2.0\n>>> \n>>> trajectory, minimum_loc, minimum_value = gradient_descent(dummy_fn, dummy_fn_grad, start_x=dummy_start_x, start_y=dummy_start_y, lr=0.01, n_steps=5, silent=True)\n>>> \n>>> target_trajectory = [np.array([[1], [2]]), np.array([[0.96], [1.95]]), np.array([[0.92], [1.9]]),\n...                     np.array([[0.88], [1.85]]), np.array([[0.84], [1.8]]), np.array([[0.8], [1.75]])]\n>>> \n>>> np.array([np.isclose(target.flatten(), output.flatten(), atol=1e-3) for target, output in zip(target_trajectory, trajectory)]).all()\nTrue",
+         "code": ">>> c = np.array([[4], [5]])\n>>> dummy_fn = lambda x: float(c.T @ x)\n>>> dummy_fn_grad = lambda x: c.T\n>>> dummy_start_x1, dummy_start_x2 = 1.0, 2.0\n>>> \n>>> trajectory, minimum_loc, minimum_value = gradient_descent(dummy_fn, dummy_fn_grad, start_x1=dummy_start_x1, start_x2=dummy_start_x2, lr=0.01, n_steps=5, silent=True)\n>>> \n>>> target_trajectory = [np.array([[1], [2]]), np.array([[0.96], [1.95]]), np.array([[0.92], [1.9]]),\n...                     np.array([[0.88], [1.85]]), np.array([[0.84], [1.8]]), np.array([[0.8], [1.75]])]\n>>> \n>>> np.array([np.isclose(target.flatten(), output.flatten(), atol=1e-3) for target, output in zip(target_trajectory, trajectory)]).all()\nTrue",
          "failure_message": "Gradient Descent Trajectory Test Failed",
          "hidden": false,
          "locked": false,
@@ -1038,7 +1037,7 @@
          "success_message": "Gradient Descent Trajectory Test Passed"
         },
         {
-         "code": ">>> c = np.array([[4], [5]])\n>>> dummy_fn = lambda x: float(c.T @ x)\n>>> dummy_fn_grad = lambda x: c.T\n>>> dummy_start_x, dummy_start_y = 1.0, 2.0\n>>> \n>>> trajectory, minimum_loc, minimum_value = gradient_descent(dummy_fn, dummy_fn_grad, start_x=dummy_start_x, start_y=dummy_start_y, lr=0.01, n_steps=5, silent=True)\n>>> target_minimum_loc = np.array([[0.8], [1.75]])\n>>> np.isclose(target_minimum_loc, minimum_loc, atol=1e-3).all()\nTrue",
+         "code": ">>> c = np.array([[4], [5]])\n>>> dummy_fn = lambda x: float(c.T @ x)\n>>> dummy_fn_grad = lambda x: c.T\n>>> dummy_start_x1, dummy_start_x2 = 1.0, 2.0\n>>> \n>>> trajectory, minimum_loc, minimum_value = gradient_descent(dummy_fn, dummy_fn_grad, start_x1=dummy_start_x1, start_x2=dummy_start_x2, lr=0.01, n_steps=5, silent=True)\n>>> target_minimum_loc = np.array([[0.8], [1.75]])\n>>> np.isclose(target_minimum_loc, minimum_loc, atol=1e-3).all()\nTrue",
          "failure_message": "Gradient Descent Minimum Location Test Failed",
          "hidden": false,
          "locked": false,
@@ -1046,7 +1045,7 @@
          "success_message": "Gradient Descent Minimum Location Test Passed"
         },
         {
-         "code": ">>> c = np.array([[4], [5]])\n>>> dummy_fn = lambda x: float(c.T @ x)\n>>> dummy_fn_grad = lambda x: c.T\n>>> dummy_start_x, dummy_start_y = 1.0, 2.0\n>>> \n>>> trajectory, minimum_loc, minimum_value = gradient_descent(dummy_fn, dummy_fn_grad, start_x=dummy_start_x, start_y=dummy_start_y, lr=0.01, n_steps=5, silent=True)\n>>> target_minimum_value = 11.949999999999998\n>>> np.isclose(target_minimum_value, minimum_value, atol=1e-3)\nTrue",
+         "code": ">>> c = np.array([[4], [5]])\n>>> dummy_fn = lambda x: float(c.T @ x)\n>>> dummy_fn_grad = lambda x: c.T\n>>> dummy_start_x1, dummy_start_x2 = 1.0, 2.0\n>>> \n>>> trajectory, minimum_loc, minimum_value = gradient_descent(dummy_fn, dummy_fn_grad, start_x1=dummy_start_x1, start_x2=dummy_start_x2, lr=0.01, n_steps=5, silent=True)\n>>> target_minimum_value = 11.949999999999998\n>>> np.isclose(target_minimum_value, minimum_value, atol=1e-3)\nTrue",
          "failure_message": "Gradient Descent Minimum Value Test Failed",
          "hidden": false,
          "locked": false,
@@ -1175,7 +1174,7 @@
       {
        "cases": [
         {
-         "code": ">>> p = np.random.rand(4)\n>>> q = np.random.rand(4)\n>>> x = np.random.rand(4)\n>>> (4,) == sq_dist_grad(p,q,x).shape \nTrue",
+         "code": ">>> p = np.random.rand(4)\n>>> q = np.random.rand(4)\n>>> z = np.random.rand(4)\n>>> (4,) == sq_dist_grad(p,q,z).shape \nTrue",
          "failure_message": "Squared Distance Gradient Function Shape Test Failed",
          "hidden": false,
          "locked": false,

--- a/coursework/mml_cw_1.ipynb
+++ b/coursework/mml_cw_1.ipynb
@@ -581,11 +581,11 @@
     "\n",
     "#### Question 4.a - Forward Pass of the Squared Distances function (1 Point)\n",
     "In particular, we'll consider the gradient of \n",
-    "$$ \\vec{s} = \\vec{p}^T \\mathbf{D} \\vec{q}, $$\n",
+    "$$ s = \\vec{p}^T \\mathbf{D} \\vec{q}, $$\n",
     "with respect to $\\vec{z}$, where $\\vec{p}$ and $\\vec{q}$ are constants, and $\\mathbf{D}$ is the matrix of squared distances between elements of $\\vec{z}$:\n",
     "$$ D_{ij} = \\exp(-(z_i - z_j)^2). $$\n",
     "\n",
-    "Get warmed up by implementing the the function ```sq_dist_fwd(p,q,z)``` which computes $\\vec{s}$."
+    "Get warmed up by implementing the the function ```sq_dist_fwd(p,q,z)``` which computes $s$."
    ]
   },
   {
@@ -635,7 +635,7 @@
    "source": [
     "#### Question 4.b - Analytical Derivate of Squared Distances (2 Points)\n",
     "In order to override autograd's gradient for our squared distance function, we need to derive it ourselves - compute the derivate\n",
-    "$$\\frac{\\partial \\vec{s}}{\\partial \\vec{z}} =\\sum_{i j} p_i q_j \\frac{\\partial D_{i j}}{\\partial \\vec{z}} $$\n",
+    "$$\\frac{\\partial s}{\\partial \\vec{z}} =\\sum_{i j} p_i q_j \\frac{\\partial D_{i j}}{\\partial \\vec{z}} $$\n",
     "with respect to one element of $\\vec{z}$\n"
    ]
   },
@@ -721,7 +721,7 @@
     "You should see that our implementation of the gradient function requires considerably less memory than the one autograd provides by using autodiff. \n",
     "\n",
     "Now let's tell autograd to use our analytically derived gradient function when computing autodiff for a more complicated function:\n",
-    "$$ \\vec{y} = \\vec{s} = \\vec{p}^T \\mathbf{D}(\\vec{z}) \\vec{q}, \\quad \\text{and} \\quad \\vec{z} = 3\\sin{x}+5$$\n",
+    "$$ \\vec{y} = s = \\vec{p}^T \\mathbf{D}(\\vec{z}) \\vec{q}, \\quad \\text{and} \\quad \\vec{z} = 3\\sin{x}+5$$\n",
     "\n",
     "We'll start by revisiting our toy example of $x^2$."
    ]

--- a/coursework/mml_cw_1.ipynb
+++ b/coursework/mml_cw_1.ipynb
@@ -882,38 +882,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "\"\"\"Question 4.e.i - Create a (rough) computational graph for the function\"\"\"\n",
-    "\n",
-    "from graphviz import Digraph\n",
-    "comp_graph = Digraph('Computational Graph') # Create Digraph object\n",
-    "\n",
-    "with comp_graph.subgraph(name='cluster_0') as c:\n",
-    "    c.attr(style='filled', color='pink', label='First Function')\n",
-    "    c.node_attr.update(style='filled', color='white')\n",
-    "    c.edges([('x', 'sin(x)')])\n",
-    "\n",
-    "with comp_graph.subgraph(name='cluster_1') as c:\n",
-    "    c.attr(style='filled', color='lightblue', label='Squared Distance Function')\n",
-    "    c.node_attr.update(style='filled', color='white')\n",
-    "    c.edges([('placeholder1', 'placeholder2')])\n",
-    "    \n",
-    "comp_graph.node('z')\n",
-    "comp_graph.edge('sin(x)', 'z')\n",
-    "comp_graph.edge('z', 'placeholder1')\n",
-    "\n",
-    "comp_graph.attr(label=r'\\n\\nComputational Graph ANSWER for Q4')\n",
-    "comp_graph.attr(fontsize='20')\n",
-    "comp_graph "
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/coursework/mml_cw_1.ipynb
+++ b/coursework/mml_cw_1.ipynb
@@ -782,7 +782,7 @@
     "sq_dist_fwd_wrapped = partial(sq_dist_fwd, p, q)\n",
     "sq_dist_grad_wrapped = partial(sq_dist_grad, p, q)\n",
     "\n",
-    "@partial \n",
+    "@primitive \n",
     "def sq_dist(z):\n",
     "    # Tell autograd we a custom gradient for sq_dist\n",
     "    ...\n",

--- a/exercises/multivariate_probability_answers.tex
+++ b/exercises/multivariate_probability_answers.tex
@@ -8,8 +8,8 @@ $$p_Y(\y) = p_X(T^{-1}(\y)) | \frac{dT^{-1}(\y)}{dy} | .$$
 As $T^{-1}(\y) = \BA^{-1} \y$, we have $| \frac{dT^{-1}(y)}{dy} | = | \BA^{-1} | = | \BA |^{-1}$. Plugging in these results:
 \begin{equation*}
 \begin{aligned}
-p_Y(\y) &=  |\BA |^{-1} \frac{1}{\sqrt{(2 \pi)^d |\Sigma|}} \exp[-\frac{1}{2} (\BA^{-1} \x - \bm{\mu})^\top \Sigma^{-1} (\BA^{-1} \x - \bm{\mu})] \\
-& = \frac{1}{\sqrt{(2 \pi)^d |\BA \Sigma \BA^\top|}} \exp[-\frac{1}{2} (\x - \BA \bm{\mu})^\top (\BA \Sigma \BA^{\top})^{-1} ( \x - \BA \bm{\mu})].
+p_Y(\y) &=  |\BA |^{-1} \frac{1}{\sqrt{(2 \pi)^d |\Sigma|}} \exp[-\frac{1}{2} (\BA^{-1} \y - \bm{\mu})^\top \Sigma^{-1} (\BA^{-1} \y - \bm{\mu})] \\
+& = \frac{1}{\sqrt{(2 \pi)^d |\BA \Sigma \BA^\top|}} \exp[-\frac{1}{2} (\y - \BA \bm{\mu})^\top (\BA \Sigma \BA^{\top})^{-1} ( \y - \BA \bm{\mu})].
 \end{aligned}
 \end{equation*}
 

--- a/exercises/multivariate_probability_answers.tex
+++ b/exercises/multivariate_probability_answers.tex
@@ -62,7 +62,7 @@ As we define $\Lambda = \Sigma^{-1}$, the PDF of the multivariate Gaussian is (w
 p(X = \x) &= \frac{1}{\sqrt{ (2 \pi)^d | \Sigma |}} \exp [ -\frac{1}{2} (\x - \bm{\mu})^\top \Lambda (\x - \bm{\mu})^\top ] \\
 &= \frac{1}{\sqrt{ (2 \pi)^d | \Sigma |}} \exp [ -\frac{1}{2} \sum_k \sum_l (x_k - \mu_k) \Lambda_{kl} (x_l - \mu_l) ] \\
 &= \frac{1}{\sqrt{ (2 \pi)^d | \Sigma |}} \exp [ -\frac{1}{2} [ f(x_i) + g(x_j) + \sum_{k \neq i, j} \sum_l (x_k - \mu_k) \Lambda_{kl} (x_l - \mu_l) ] ], \\
-\text{where} \quad f(x_i) &= \Lambda_{ii} (x_i - \mu_i)^2 + (x_i - \mu_i) \sum_{l \neq i. j} \Lambda_{il} (x_l - \mu_l), \\
+\text{where} \quad f(x_i) &= \Lambda_{ii} (x_i - \mu_i)^2 + (x_i - \mu_i) \sum_{l \neq i, j} \Lambda_{il} (x_l - \mu_l), \\
 g(x_j) &= \Lambda_{jj} (x_j - \mu_j)^2 + (x_j - \mu_j) \sum_{l \neq i, j} \Lambda_{jl} (x_l - \mu_l).
 \end{aligned}
 \end{equation*}

--- a/slides/L07P1-multivariate-prob-cont.tex
+++ b/slides/L07P1-multivariate-prob-cont.tex
@@ -221,7 +221,7 @@ What is the joint distribution $p(X_1, X_2, X_3, X_4)$ for the card draws --
 
 Univariate case:
 $$\text{mean:} \quad \mathbb{E}[X] = \int x p_X(x) dx $$
-$$\text{variance:} \mathbb{V}[X] = \mathbb{E}[(X - \mathbb{E}[X])] = \int (x - \mathbb{E}[X]) p_X(x) dx $$
+$$\text{variance:} \mathbb{V}[X] = \mathbb{E}[(X - \mathbb{E}[X])^2] = \int (x - \mathbb{E}[X])^2 p_X(x) dx $$
 
 Multivariate case: write $X = (X_1, ..., X_N)^\top$
 $$\text{mean:} \quad \mathbb{E}[X] = (\mathbb{E}[X_1], ..., \mathbb{E}[X_N])^\top $$

--- a/slides/l09p1-concentration.tex
+++ b/slides/l09p1-concentration.tex
@@ -281,10 +281,10 @@ Q2: How big should our test set be, to get a certain accuracy?
 \end{gather} \pause
 
 \begin{itemize}
-\item For $\epsilon = 0.001$, and $\delta = \frac{0.25}{N\epsilon^2} < 0.05$, we need $N > 5\cdot 10^6$!
-\item For $\epsilon = 0.001$, and $\delta = \frac{0.25}{N\epsilon^2} < 0.01$, we need $N > 25\cdot 10^6$!
-\item For $\epsilon = 0.01$, and $\delta = \frac{0.25}{N\epsilon^2} < 0.05$, we need $N > 50\cdot 10^3$!
-\item For $\epsilon = 0.01$, and $\delta = \frac{0.25}{N\epsilon^2} < 0.01$, we need $N > 250\cdot 10^3$!
+\item For $\epsilon = 0.001$, and $\delta = \frac{0.25}{N\epsilon^2} < 0.05$, we need $N > 5\cdot 10^6$
+\item For $\epsilon = 0.001$, and $\delta = \frac{0.25}{N\epsilon^2} < 0.01$, we need $N > 25\cdot 10^6$
+\item For $\epsilon = 0.01$, and $\delta = \frac{0.25}{N\epsilon^2} < 0.05$, we need $N > 50\cdot 10^3$
+\item For $\epsilon = 0.01$, and $\delta = \frac{0.25}{N\epsilon^2} < 0.01$, we need $N > 250\cdot 10^3$
 \end{itemize}
 \end{frame}
 

--- a/slides/l11p1-bayesgauss.tex
+++ b/slides/l11p1-bayesgauss.tex
@@ -87,7 +87,7 @@ p(v|s) &= \NormDist{v; s, \sigma^2} && \text{Assumptions about the channel.}
 
 We are interested in our posterior belief on $S$:
 \begin{align}
-p(s|v) &= \frac{p(v|s)p(v)}{p(v)} \\
+p(s|v) &= \frac{p(v|s)p(s)}{p(v)} \\
 &= \frac{p(v,s)}{\int p(v,s) \mathrm ds} && \text{Alternative formulation (sum/prod rules)}
 \end{align}
 \end{frame}


### PR DESCRIPTION
- Fix bayes rule in slides L11P1
- Remove exclamation mark on slides L09P1 to not confuse with factorial
- Change `x` to `y` after completing change of variables in exercise answers Q35
- Change sum over `i, j` instead of `i. j` in exercise answers Q38
- Fix variance formula in L07P1