### PR TITLE
Typos in Questions 24 c, 35

### DIFF
--- a/exercises/answers-lecture2-diff.tex
+++ b/exercises/answers-lecture2-diff.tex
@@ -251,7 +251,7 @@ Dimensions are
     
 \begin{align*}
 \frac{\partial f}{\partial \textbf{x}} &= \frac{\partial f}{\partial z} \frac{\partial z}{\partial \textbf{y}}\frac{\partial \textbf{y}}{\partial \textbf{x}} = \frac{\partial \exp(-\frac{1}{2}z)}{\partial z} \frac{\partial (\textbf{y}^TS^{-1}\textbf{y})}{\partial \textbf{y}}\frac{\partial (\textbf{x} - \bm{\mu})}{\partial \textbf{x}} = \exp\left(-\frac{1}{2}z\right)\left(-\frac{1}{2}\right)\textbf{y}^T(S^T + S^{-T})I \\
-&=-\frac{1}{2}\exp\left(-\frac{1}{2}\Big((\textbf{x} - \bm{\mu})^TS^{-1}(\textbf{x} - \bm{\mu})\Big)\right)(\textbf{x} - \bm{\mu})^T(S^T + S^{-T})
+&=-\frac{1}{2}\exp\left(-\frac{1}{2}\Big((\textbf{x} - \bm{\mu})^TS^{-1}(\textbf{x} - \bm{\mu})\Big)\right)(\textbf{x} - \bm{\mu})^T(S^{-1} + S^{-T})
 \end{align*}
 where $S^{-T} = \left(S^{-1}\right)^T$, and we use (5.107) to calculate $\frac{\partial (\textbf{y}^TS^{-1}\textbf{y})}{\partial \textbf{y}}$.
 

--- a/exercises/multivariate_probability_answers.tex
+++ b/exercises/multivariate_probability_answers.tex
@@ -8,8 +8,8 @@ $$p_Y(\y) = p_X(T^{-1}(\y)) | \frac{dT^{-1}(\y)}{dy} | .$$
 As $T^{-1}(\y) = \BA^{-1} \y$, we have $| \frac{dT^{-1}(y)}{dy} | = | \BA^{-1} | = | \BA |^{-1}$. Plugging in these results:
 \begin{equation*}
 \begin{aligned}
-p_Y(\y) &=  |\BA |^{-1} \frac{1}{\sqrt{(2 \pi)^d |\Sigma|}} \exp[-\frac{1}{2} (\BA^{-1} \x - \bm{\mu})^\top \Sigma^{-1} (\BA^{-1} \x - \bm{\mu})] \\
-& = \frac{1}{\sqrt{(2 \pi)^d |\BA \Sigma \BA^\top|}} \exp[-\frac{1}{2} (\x - \BA \bm{\mu})^\top (\BA \Sigma \BA^{\top})^{-1} ( \x - \BA \bm{\mu})].
+p_Y(\y) &=  |\BA |^{-1} \frac{1}{\sqrt{(2 \pi)^d |\Sigma|}} \exp[-\frac{1}{2} (\BA^{-1} \y - \bm{\mu})^\top \Sigma^{-1} (\BA^{-1} \y - \bm{\mu})] \\
+& = \frac{1}{\sqrt{(2 \pi)^d |\BA \Sigma \BA^\top|}} \exp[-\frac{1}{2} (\y - \BA \bm{\mu})^\top (\BA \Sigma \BA^{\top})^{-1} ( \y - \BA \bm{\mu})].
 \end{aligned}
 \end{equation*}
 


### PR DESCRIPTION
Hello,

I recently checked questions 24 c and 35 with a TA, and think that there might be a typo. 

For 24 c), I believe the derivative of $y^{T}S^{-1}y$ should be $y^{T}(S^{-1} + S^{-T})$ rather than $y^{T}(S^{T} + S^{-T})$ (following MML 5.107).

For 35, I believe that there was a typo plugging in $p_Y(y) = p_X(T^{-1}(y))$, where $T^{-1}(y) = A^{-1}y$, but was plugged in as $A^{-1}x$.

Thank you!